### PR TITLE
Fix/codex history title agents injection

### DIFF
--- a/apps/proxy/src/__tests__/unit/session-history.test.ts
+++ b/apps/proxy/src/__tests__/unit/session-history.test.ts
@@ -375,7 +375,7 @@ describe("scanSessionHistory", () => {
     expect(result[0].title).toBe("Same question");
   });
 
-  it("does NOT dedup when all user messages are isMeta and titles fall back to unique session IDs", async () => {
+  it("does NOT dedup untitled sessions in the same project (keys fall back to session id)", async () => {
     // All user messages are metadata, so the title falls back to the sessionId prefix.
     const older = writeSession("-test-proj", "aaaaaaaa-1111", [
       JSON.stringify({
@@ -411,10 +411,10 @@ describe("scanSessionHistory", () => {
     utimesSync(newer, new Date(2_000), new Date(2_000));
 
     const result = await scanSessionHistory();
-    // 没有真实标题时统一显示未命名；同一 provider + projectDir + title 会折叠到最新一条。
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("bbbbbbbb-2222");
-    expect(result[0].title).toBe("未命名会话");
+    // 没有真实标题时统一显示未命名，但去重键回退到 session id，避免不同会话被误折叠成一条。
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.id).sort()).toEqual(["aaaaaaaa-1111", "bbbbbbbb-2222"]);
+    expect(result.every((r) => r.title === "未命名会话")).toBe(true);
   });
 
   it("includes Codex sessions from ~/.codex/sessions", async () => {
@@ -544,14 +544,104 @@ describe("scanSessionHistory", () => {
         payload: {
           type: "message",
           role: "user",
-          content: [{ type: "input_text", text: "engine的日志在哪里啊" }],
+          content: [{ type: "input_text", text: "第一个真实问题" }],
         },
       }),
     ]);
 
     const result = await scanSessionHistory();
     expect(result).toHaveLength(1);
-    expect(result[0].title).toBe("engine的日志在哪里啊");
+    expect(result[0].title).toBe("第一个真实问题");
+  });
+
+  it("filters Codex AGENTS.md + environment_context blocks in one message, uses next real prompt", async () => {
+    // 真实 rollout 里 Codex 把 AGENTS.md 指令和 environment_context 塞进同一条 user 消息的
+    // 两个 input_text 块; 拼接后以 `#` 开头会绕过只认 `<` 的过滤, 必须逐块剔除。
+    writeCodexSession("codex-agents", [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-agents", cwd: "/home/dev/projects/sample-app" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: "# AGENTS.md instructions for /home/dev/projects/sample-app\n\n<INSTRUCTIONS>\n# Repository Guidelines\n</INSTRUCTIONS>",
+            },
+            {
+              type: "input_text",
+              text: "<environment_context><cwd>/home/dev/projects/sample-app</cwd></environment_context>",
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "这是用户的真实提问" }],
+        },
+      }),
+    ]);
+
+    const result = await scanSessionHistory();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("这是用户的真实提问");
+  });
+
+  it("keeps distinct Codex sessions in the same project separate after AGENTS.md injection", async () => {
+    const agentsBlock = {
+      type: "input_text",
+      text: "# AGENTS.md instructions for /home/dev/projects/sample-app\n\n<INSTRUCTIONS>\n</INSTRUCTIONS>",
+    };
+    writeCodexSession("codex-multi-1", [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-multi-1", cwd: "/home/dev/projects/sample-app" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "message", role: "user", content: [agentsBlock] },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "第一个会话的问题" }],
+        },
+      }),
+    ]);
+    writeCodexSession("codex-multi-2", [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-multi-2", cwd: "/home/dev/projects/sample-app" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: { type: "message", role: "user", content: [agentsBlock] },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "第二个会话的问题" }],
+        },
+      }),
+    ]);
+
+    const result = await scanSessionHistory();
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.title).sort()).toEqual([
+      "第一个会话的问题",
+      "第二个会话的问题",
+    ]);
   });
 
   it("keeps Claude and Codex entries with the same title and cwd separate", async () => {

--- a/apps/proxy/src/serve/session-history.ts
+++ b/apps/proxy/src/serve/session-history.ts
@@ -47,6 +47,10 @@ const INTERNAL_TITLE_PATTERNS = [
   /^codex agent history\b/i,
   /^conversation summary\b/i,
 ];
+// Codex 会把 AGENTS.md 指令注入到首条 user 消息的一个 input_text 块里 (以 `# AGENTS.md
+// instructions for <path>` 开头), 和 <environment_context> 块并排。这些块不是用户输入,
+// 若被当作标题会让同项目所有会话标题雷同, 进而在去重时相互折叠。
+const CODEX_AGENTS_INSTRUCTIONS_PATTERN = /^#\s*AGENTS\.md instructions for\b/i;
 const CLAUDE_CONTINUATION_SUMMARY_PATTERN =
   /^This session is being continued from a previous conversation that ran out of context\.\s+The summary below covers the earlier portion of the conversation\.\s+Summary:/i;
 const TEMP_HISTORY_ROOTS = expandPathAliases([tmpdir(), "/tmp", "/private/tmp", "/var/tmp"])
@@ -63,10 +67,13 @@ export async function scanSessionHistory(
     readSessionHistoryMetadata(options.metadataPath),
   ).filter((entry) => !isTemporaryProjectDir(entry.projectDir));
   entries.sort((a, b) => b.updatedAt - a.updatedAt);
-  // 按 provider + title + projectDir 去重，resume 产生的多个 session 只保留最新的
+  // 按 provider + projectDir + title 去重，resume 产生的多个 session 只保留最新的。
+  // 兜底: 标题回退为「未命名会话」时改用 session id 参与去重, 避免提取不到标题的不同会话
+  // 被错误折叠成一条 (真实标题相同仍按设计折叠)。
   const seen = new Set<string>();
   const uniqueEntries = entries.filter((e) => {
-    const key = `${e.provider}::${e.projectDir}::${e.title}::${e.preferredMode ?? "unknown"}`;
+    const titleKey = e.title === UNTITLED_SESSION_TITLE ? `id:${e.id}` : e.title;
+    const key = `${e.provider}::${e.projectDir}::${titleKey}::${e.preferredMode ?? "unknown"}`;
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
@@ -723,7 +730,18 @@ function extractCodexUserText(payload: unknown): string | null {
       const typed = block as { type?: unknown; text?: unknown };
       return typed.type === "input_text" && typeof typed.text === "string" ? typed.text : "";
     })
-    .filter(Boolean);
+    .filter(Boolean)
+    .filter((text) => !isCodexInjectedContextBlock(text));
   const joined = texts.join("\n").trim();
   return normalizeHistoryTitle(joined);
+}
+
+// 判断某个 input_text 块是否为 Codex 自动注入的上下文 (AGENTS.md 指令 / environment_context)。
+// 逐块过滤而非拼接后再判断: 注入块常与真实内容混在同一条消息, 且 `# AGENTS.md...` 以 `#`
+// 开头会绕过 normalizeHistoryTitle 里只认 `<` 开头的噪音过滤。
+function isCodexInjectedContextBlock(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    CODEX_AGENTS_INSTRUCTIONS_PATTERN.test(trimmed) || trimmed.startsWith("<environment_context>")
+  );
 }


### PR DESCRIPTION
Codex 会把 `# AGENTS.md instructions for ...` 和 <environment_context> 注入到首条 user 消息, 导致同项目所有会话标题雷同、去重时相互折叠。

- 提取标题时逐块过滤 Codex 注入的上下文块, 回落到真实用户输入
- 去重键在标题为「未命名会话」时改用 session id, 避免不同会话被误折叠