### PR TITLE
fix(proxy): restore Windows service access and configure update retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   automatic-updates:
     name: Native automatic update (${{ matrix.os }}, ${{ matrix.mode }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - name: Verify consecutive upgrades, retained shells and the real 15-minute retry
+      - name: Verify consecutive upgrades, retained shells and automatic retry
+        env:
+          DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS: "10000"
         run: pnpm --filter @dev-anywhere/proxy exec tsx scripts/verify-auto-update.ts --${{ matrix.mode }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Test a disposable SCM service under an ordinary user without desktop login
         env:
           DEV_ANYWHERE_TEST_SYSTEM_SERVICE: "1"
-        run: pnpm --filter @dev-anywhere/proxy exec vitest run src/__tests__/integration/windows-system-service.test.ts --maxWorkers=1 --hookTimeout=30000
+        run: pnpm --filter @dev-anywhere/proxy exec vitest run src/__tests__/integration/windows-system-service.test.ts src/__tests__/integration/windows-pipe-permissions.test.ts --maxWorkers=1 --hookTimeout=30000
       - name: Test native processes, IPC, terminal handover and startup registration
         shell: pwsh
         run: |

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -134,9 +134,16 @@ services and shells. Each job checks:
 
 - Two consecutive Relay-directed upgrades with the original terminal still usable.
 - A stalled package download, local package recovery and the old daemon staying available.
-- Success after the real 15-minute retry interval, without manually installing the
+- Success after the configured retry interval, without manually installing the
   target version or restarting Proxy.
 - The system service host and terminal worker keeping their original process identities.
+
+CI sets `DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS=10000` so failure recovery waits
+10 seconds before retrying. The acceptance script uses the same default; set the
+variable to override it. This changes only the waiting interval: the real timer,
+npm download, package recovery and service restart still run. Production defaults
+to 15 minutes, with exponential backoff capped at six hours; unit tests verify
+those defaults without waiting in real time.
 
 Windows system service acceptance uses a disposable ordinary account without a
 desktop login. Workflow artifacts retain service and updater logs. A failed,

--- a/apps/proxy/scripts/verify-auto-update.ts
+++ b/apps/proxy/scripts/verify-auto-update.ts
@@ -14,14 +14,17 @@ import { spawnCommand } from "../src/common/command-launch.js";
 import { buildProxyProfilePaths } from "../src/common/paths.js";
 import { requestServiceControl } from "../src/common/service-control.js";
 import { requestServiceHost } from "../src/common/service-host-control.js";
+import { loadProxyRuntimeEnv } from "../src/common/runtime-env.js";
 import { installAcceptanceService } from "./auto-update-service.js";
 
 // Full native acceptance: packaged entrypoints, the real Relay, real npm installs, an OS
-// service (or detached daemon), and an interactive shell. No updater mocks or shorter timers.
+// service (or detached daemon), and an interactive shell. Only the retry interval is shortened;
+// the packaged updater, npm, OS services and clock all run normally.
 // Start from the published 0.9.8 package. The two higher candidate versions belong only to
 // this loopback registry and are never published. The second upgrade exercises the new updater.
 if (process.env.CI !== "true") throw new Error("Run on a disposable native CI host");
 const mode = process.argv.includes("--daemon") ? "daemon" : "system";
+const retryInitialMs = loadProxyRuntimeEnv().autoUpdateRetryInitialMs ?? 10_000;
 const source = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const baselineVersion = "0.9.8";
 const sourceVersion = JSON.parse(await readFile(join(source, "package.json"), "utf8"))
@@ -129,17 +132,15 @@ await new Promise<void>((done) => registry.listen(0, "127.0.0.1", done));
 const registryAddress = registry.address();
 assert(registryAddress && typeof registryAddress === "object");
 const registryUrl = `http://127.0.0.1:${registryAddress.port}`;
-const env = {
-  ...process.env,
+const runtimeEnv = {
   npm_config_prefix: prefix,
   npm_config_cache: join(root, "npm-cache"),
   npm_config_registry: registryUrl,
+  DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS: String(retryInitialMs),
 };
+const env = { ...process.env, ...runtimeEnv };
 const environmentModule = join(root, "environment.mjs");
-await writeFile(
-  environmentModule,
-  `Object.assign(process.env, ${JSON.stringify({ npm_config_prefix: prefix, npm_config_cache: env.npm_config_cache, npm_config_registry: registryUrl })});`,
-);
+await writeFile(environmentModule, `Object.assign(process.env, ${JSON.stringify(runtimeEnv)});`);
 
 async function command(command: string, args: string[], cwd = root) {
   return new Promise<string>((done, reject) => {
@@ -352,7 +353,7 @@ async function checkShell(label: string) {
   log("original_shell_responded", { label, sessionId, workerPid: originalWorkerPid, shellPid });
 }
 try {
-  log("acceptance_started", { node: process.version, root });
+  log("acceptance_started", { node: process.version, root, retryInitialMs });
   for (const version of [firstTargetVersion, retryTargetVersion]) {
     await pack("relay", version);
     await pack("proxy", version);
@@ -475,7 +476,7 @@ try {
     async () => (await logs("service")).find((item) => item.msg === "Proxy auto-update will retry"),
     7 * 60000,
   );
-  assert.equal(retry.retryInMs, 900000, "The production retry timer must remain 15 minutes");
+  assert.equal(retry.retryInMs, retryInitialMs, "The packaged updater ignored its retry interval");
   assert(blockedRequests > 0, "The updater did not attempt the real tarball download");
   const stillRunning = await status();
   assert.equal(stillRunning?.pid, updated.pid, "Download failure stopped the old daemon");
@@ -488,17 +489,26 @@ try {
   await connectBrowser();
   await checkShell("after-download-failure");
   blockTarball = false;
-  log("failure_recovered_waiting_for_real_retry", { retry, blockedRequests });
+  log("failure_recovered_waiting_for_retry", { retry, blockedRequests });
   const recovered = await waitFor(
-    "default automatic retry succeeds",
+    "automatic retry succeeds",
     async () => {
       const current = await status();
       return current?.version === retryTargetVersion && current.info?.relay?.connected
         ? current
         : null;
     },
-    20 * 60000,
+    retryInitialMs + 6 * 60000,
   );
+  const retryStarted = (await logs("service")).find(
+    (item) =>
+      item.msg === "Starting Relay-directed Proxy auto-update" &&
+      item.targetVersion === retryTargetVersion &&
+      Number(item.time) > Number(retry.time),
+  );
+  assert(retryStarted, "The failed update did not start another runner automatically");
+  const retryWaitMs = Number(retryStarted.time) - Number(retry.time);
+  assert(retryWaitMs >= retryInitialMs, "The retry ran before its configured interval");
   assert.notEqual(recovered.pid, updated.pid);
   assert.equal((await command(process.execPath, [entry, "--version"])).trim(), retryTargetVersion);
   client?.terminate();
@@ -517,6 +527,7 @@ try {
     originalWorkerPid,
     originalShellPid,
     retryInMs: retry.retryInMs,
+    retryWaitMs,
   });
 } catch (error) {
   for (const kind of ["service", "auto-update", "terminal"])

--- a/apps/proxy/src/__tests__/integration/windows-pipe-permissions.test.ts
+++ b/apps/proxy/src/__tests__/integration/windows-pipe-permissions.test.ts
@@ -1,0 +1,161 @@
+import { execFile, execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { psString } from "#src/common/autostart-definition.js";
+import { localIpcEndpointPath } from "#src/common/paths.js";
+import { setLocalIpcEndpointPermissions } from "#src/common/local-ipc-endpoint.js";
+
+// Native access checks with real Windows tokens, including the administrator's filtered token.
+// The test never needs the password of the runner or an existing user.
+const CLIENT = `using System;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+public static class PipeAccessProbe {
+  [StructLayout(LayoutKind.Sequential)]
+  private struct SidAndAttributes { public IntPtr Sid; public uint Attributes; }
+  [DllImport("kernel32.dll")] private static extern IntPtr GetCurrentProcess();
+  [DllImport("kernel32.dll")] private static extern bool CloseHandle(IntPtr handle);
+  [DllImport("advapi32.dll", SetLastError = true)]
+  private static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
+  [DllImport("advapi32.dll", SetLastError = true)]
+  private static extern bool CreateRestrictedToken(IntPtr token, uint flags, uint disabledCount,
+    SidAndAttributes[] disabled, uint deletedCount, IntPtr deleted, uint restrictedCount,
+    IntPtr restricted, out IntPtr result);
+  [DllImport("advapi32.dll", SetLastError = true)]
+  private static extern bool SetTokenInformation(IntPtr token, int kind, ref SidAndAttributes data, int length);
+  [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern bool LogonUser(string user, string domain, string password, int type, int provider, out IntPtr token);
+  private static void Check(bool success) { if (!success) throw new Win32Exception(Marshal.GetLastWin32Error()); }
+  private static IntPtr Sid(string value) {
+    var sid = new SecurityIdentifier(value);
+    var data = new byte[sid.BinaryLength]; sid.GetBinaryForm(data, 0);
+    var result = Marshal.AllocHGlobal(data.Length); Marshal.Copy(data, 0, result, data.Length);
+    return result;
+  }
+  public static int Main(string[] args) {
+    Console.OutputEncoding = new System.Text.UTF8Encoding(false);
+    IntPtr original = IntPtr.Zero, token = IntPtr.Zero, admin = IntPtr.Zero, label = IntPtr.Zero;
+    try {
+      if (args[0] == "other") {
+        Check(LogonUser(args[2], ".", args[3], 2, 0, out token));
+      } else {
+        Check(OpenProcessToken(GetCurrentProcess(), 0x02000000, out original));
+        admin = Sid("S-1-5-32-544");
+        var disabled = new[] { new SidAndAttributes { Sid = admin } };
+        Check(CreateRestrictedToken(original, 1, 1, disabled, 0, IntPtr.Zero, 0, IntPtr.Zero, out token));
+        label = Sid(args[0] == "low" ? "S-1-16-4096" : "S-1-16-8192");
+        var integrity = new SidAndAttributes { Sid = label, Attributes = 0x20 };
+        Check(SetTokenInformation(token, 25, ref integrity, Marshal.SizeOf(typeof(SidAndAttributes)) + 12));
+      }
+      using (WindowsIdentity.Impersonate(token)) {
+        var identity = WindowsIdentity.GetCurrent();
+        if (new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator))
+          throw new InvalidOperationException("Probe still has administrator access");
+        try {
+          using (var pipe = new NamedPipeClientStream(".", args[1].Substring(9), PipeDirection.InOut,
+              PipeOptions.None, TokenImpersonationLevel.Identification)) {
+            pipe.Connect(3000);
+            var request = System.Text.Encoding.UTF8.GetBytes("probe\\n");
+            pipe.Write(request, 0, request.Length); pipe.Flush();
+            using (var reader = new StreamReader(pipe)) {
+              if (reader.ReadLine() != "accepted") throw new InvalidOperationException("Invalid pipe reply");
+            }
+          }
+          Console.WriteLine("ALLOWED " + identity.User.Value);
+        } catch (UnauthorizedAccessException) { Console.WriteLine("DENIED"); }
+      }
+      return 0;
+    } catch (Exception error) { Console.Error.WriteLine(error); return 1; }
+    finally {
+      if (token != IntPtr.Zero) CloseHandle(token);
+      if (original != IntPtr.Zero) CloseHandle(original);
+      if (admin != IntPtr.Zero) Marshal.FreeHGlobal(admin);
+      if (label != IntPtr.Zero) Marshal.FreeHGlobal(label);
+    }
+  }
+}
+`;
+
+describe.skipIf(
+  process.platform !== "win32" || process.env.DEV_ANYWHERE_TEST_SYSTEM_SERVICE !== "1",
+)("Windows named-pipe account access", () => {
+  it("admits the same account without elevation and rejects other accounts and low-integrity clients", async () => {
+    const root = mkdtempSync(join(tmpdir(), "da-pipe-access-"));
+    const endpoint = localIpcEndpointPath(join(root, "control.sock"));
+    const program = join(root, "probe.exe");
+    const source = join(root, "probe.cs");
+    const user = `dap${randomUUID().replaceAll("-", "").slice(0, 10)}`;
+    const password = `${randomUUID()}Aa9!`;
+    const sockets = new Set<Socket>();
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.on("error", () => socket.destroy());
+      socket.once("close", () => sockets.delete(socket));
+      socket.once("data", () => socket.end("accepted\n"));
+    });
+    const powershell = (script: string) =>
+      execFileSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-EncodedCommand",
+          Buffer.from(`$ErrorActionPreference='Stop';\n${script}`, "utf16le").toString("base64"),
+        ],
+        { encoding: "utf8", timeout: 30_000, windowsHide: true },
+      );
+    const probe = async (mode: string) => {
+      const result = await promisify(execFile)(program, [mode, endpoint, user, password], {
+        encoding: "utf8",
+        timeout: 10_000,
+        windowsHide: true,
+      });
+      return result.stdout.trim();
+    };
+    try {
+      writeFileSync(source, CLIENT);
+      powershell(`Add-Type -Path ${psString(source)} -ReferencedAssemblies 'System.dll','System.Core.dll' -OutputAssembly ${psString(program)} -OutputType ConsoleApplication;
+New-LocalUser -Name ${psString(user)} -Password (ConvertTo-SecureString ${psString(password)} -AsPlainText -Force) -AccountNeverExpires | Out-Null;`);
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(endpoint, resolve);
+      });
+      // Reproduce the shipped default-DACL failure before applying the actual repair.
+      expect(await probe("medium")).toBe("DENIED");
+      // A new CLI child must also be able to repair its still-running pre-upgrade host.
+      const module = new URL("../../common/windows-pipe-permissions.ts", import.meta.url).href;
+      await promisify(execFile)(
+        process.execPath,
+        [
+          "--import",
+          import.meta.resolve("tsx"),
+          "--input-type=module",
+          "-e",
+          `import { setWindowsPipePermissions } from ${JSON.stringify(module)}; setWindowsPipePermissions(${JSON.stringify(endpoint)}, process.ppid);`,
+        ],
+        { timeout: 40_000, windowsHide: true },
+      );
+      for (let attempt = 0; attempt < 8; attempt++) {
+        expect(await probe("medium")).toMatch(/^ALLOWED S-1-/);
+      }
+      setLocalIpcEndpointPermissions(endpoint);
+      expect(await probe("medium")).toMatch(/^ALLOWED S-1-/);
+      expect(await probe("low")).toBe("DENIED");
+      expect(await probe("other")).toBe("DENIED");
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      powershell(`Remove-LocalUser -Name ${psString(user)} -ErrorAction SilentlyContinue;`);
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/apps/proxy/src/__tests__/integration/windows-pipe-permissions.test.ts
+++ b/apps/proxy/src/__tests__/integration/windows-pipe-permissions.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import { psString } from "#src/common/autostart-definition.js";
 import { localIpcEndpointPath } from "#src/common/paths.js";
 import { setLocalIpcEndpointPermissions } from "#src/common/local-ipc-endpoint.js";
+import { WINDOWS_SERVICE_POWERSHELL_PREAMBLE } from "#src/common/windows-service.js";
 
 // Native access checks with real Windows tokens, including the administrator's filtered token.
 // The test never needs the password of the runner or an existing user.
@@ -109,7 +110,9 @@ describe.skipIf(
           "-NoProfile",
           "-NonInteractive",
           "-EncodedCommand",
-          Buffer.from(`$ErrorActionPreference='Stop';\n${script}`, "utf16le").toString("base64"),
+          Buffer.from(`${WINDOWS_SERVICE_POWERSHELL_PREAMBLE}\n${script}`, "utf16le").toString(
+            "base64",
+          ),
         ],
         { encoding: "utf8", timeout: 30_000, windowsHide: true },
       );
@@ -124,7 +127,8 @@ describe.skipIf(
     try {
       writeFileSync(source, CLIENT);
       powershell(`Add-Type -Path ${psString(source)} -ReferencedAssemblies 'System.dll','System.Core.dll' -OutputAssembly ${psString(program)} -OutputType ConsoleApplication;
-New-LocalUser -Name ${psString(user)} -Password (ConvertTo-SecureString ${psString(password)} -AsPlainText -Force) -AccountNeverExpires | Out-Null;`);
+$account = New-LocalUser -Name ${psString(user)} -Password (ConvertTo-SecureString ${psString(password)} -AsPlainText -Force) -AccountNeverExpires;
+Add-LocalGroupMember -SID 'S-1-5-32-545' -Member $account;`);
       await new Promise<void>((resolve, reject) => {
         server.once("error", reject);
         server.listen(endpoint, resolve);
@@ -154,7 +158,9 @@ New-LocalUser -Name ${psString(user)} -Password (ConvertTo-SecureString ${psStri
     } finally {
       for (const socket of sockets) socket.destroy();
       await new Promise<void>((resolve) => server.close(() => resolve()));
-      powershell(`Remove-LocalUser -Name ${psString(user)} -ErrorAction SilentlyContinue;`);
+      powershell(
+        `if (Get-LocalUser -Name ${psString(user)} -ErrorAction SilentlyContinue) { Remove-LocalUser -Name ${psString(user)}; }; exit 0;`,
+      );
       rmSync(root, { recursive: true, force: true });
     }
   }, 60_000);

--- a/apps/proxy/src/__tests__/integration/windows-pipe-permissions.test.ts
+++ b/apps/proxy/src/__tests__/integration/windows-pipe-permissions.test.ts
@@ -135,24 +135,10 @@ Add-LocalGroupMember -SID 'S-1-5-32-545' -Member $account;`);
       });
       // Reproduce the shipped default-DACL failure before applying the actual repair.
       expect(await probe("medium")).toBe("DENIED");
-      // A new CLI child must also be able to repair its still-running pre-upgrade host.
-      const module = new URL("../../common/windows-pipe-permissions.ts", import.meta.url).href;
-      await promisify(execFile)(
-        process.execPath,
-        [
-          "--import",
-          import.meta.resolve("tsx"),
-          "--input-type=module",
-          "-e",
-          `import { setWindowsPipePermissions } from ${JSON.stringify(module)}; setWindowsPipePermissions(${JSON.stringify(endpoint)}, process.ppid);`,
-        ],
-        { timeout: 40_000, windowsHide: true },
-      );
+      setLocalIpcEndpointPermissions(endpoint);
       for (let attempt = 0; attempt < 8; attempt++) {
         expect(await probe("medium")).toMatch(/^ALLOWED S-1-/);
       }
-      setLocalIpcEndpointPermissions(endpoint);
-      expect(await probe("medium")).toMatch(/^ALLOWED S-1-/);
       expect(await probe("low")).toBe("DENIED");
       expect(await probe("other")).toBe("DENIED");
     } finally {

--- a/apps/proxy/src/__tests__/unit/auto-update.test.ts
+++ b/apps/proxy/src/__tests__/unit/auto-update.test.ts
@@ -51,6 +51,7 @@ const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   vi.mocked(spawn).mockReset();
   vi.mocked(terminateOwnedProcessTree).mockClear();
   Object.defineProperty(process, "platform", platformDescriptor);
@@ -495,6 +496,48 @@ describe("auto-update restart recovery", () => {
 });
 
 describe("Relay auto-update coordinator", () => {
+  it.each([
+    {
+      interval: undefined,
+      delays: [900000, 1800000, 3600000, 7200000, 14400000, 21600000, 21600000],
+    },
+    { interval: "10000", delays: [10000, 20000, 40000] },
+  ])(
+    "uses the configured retry interval with exponential backoff: $interval",
+    async ({ interval, delays }) => {
+      vi.useFakeTimers();
+      vi.stubEnv("DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS", interval);
+      const child = fakeChild();
+      const spawnRunner = vi.fn(() => child);
+      const logger = fakeLogger();
+      const updater = createRelayAutoUpdater({
+        enabled: true,
+        packagedRuntime: true,
+        profileName: "default",
+        relayName: "cloud",
+        runningVersion: "0.9.9",
+        logger,
+        spawnRunner,
+      });
+      try {
+        updater.considerRelayVersion("0.9.10");
+        for (const [index, delay] of delays.entries()) {
+          child.emit("exit", 1);
+          expect(logger.warn).toHaveBeenLastCalledWith(
+            { targetVersion: "0.9.10", retryInMs: delay, attempt: index + 1 },
+            "Proxy auto-update will retry",
+          );
+          await vi.advanceTimersByTimeAsync(delay - 1);
+          expect(spawnRunner).toHaveBeenCalledTimes(index + 1);
+          await vi.advanceTimersByTimeAsync(1);
+          expect(spawnRunner).toHaveBeenCalledTimes(index + 2);
+        }
+      } finally {
+        updater.dispose();
+      }
+    },
+  );
+
   it("starts one runner for a newer Relay and retries a failed update", async () => {
     vi.useFakeTimers();
     const children: ChildProcess[] = [];

--- a/apps/proxy/src/__tests__/unit/local-ipc-endpoint.test.ts
+++ b/apps/proxy/src/__tests__/unit/local-ipc-endpoint.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { chmodSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { setWindowsPipePermissions } from "#src/common/windows-pipe-permissions.js";
 import {
   isNamedPipeEndpoint,
   localIpcEndpointMayExist,
@@ -14,6 +15,9 @@ vi.mock("node:fs", () => ({
   mkdirSync: vi.fn(),
   unlinkSync: vi.fn(),
 }));
+vi.mock("#src/common/windows-pipe-permissions.js", () => ({
+  setWindowsPipePermissions: vi.fn(),
+}));
 
 afterEach(() => vi.clearAllMocks());
 
@@ -23,6 +27,7 @@ describe("local IPC filesystem boundary", () => {
       expect(isNamedPipeEndpoint(endpoint)).toBe(true);
       prepareLocalIpcEndpoint(endpoint);
       setLocalIpcEndpointPermissions(endpoint);
+      expect(setWindowsPipePermissions).toHaveBeenCalledWith(endpoint);
       removeLocalIpcEndpoint(endpoint);
       expect(localIpcEndpointMayExist(endpoint)).toBe(true);
     }

--- a/apps/proxy/src/__tests__/unit/runtime-env.test.ts
+++ b/apps/proxy/src/__tests__/unit/runtime-env.test.ts
@@ -8,6 +8,7 @@ describe("loadProxyRuntimeEnv", () => {
       relayUrl: undefined,
       relayProxyToken: undefined,
       hookPort: undefined,
+      autoUpdateRetryInitialMs: undefined,
       claudeBin: undefined,
       codexBin: undefined,
       kimiBin: undefined,
@@ -44,6 +45,18 @@ describe("loadProxyRuntimeEnv", () => {
     expect(loadProxyRuntimeEnv({ LOG_LEVEL: "debug" }).logLevel).toBe("debug");
     expect(loadProxyRuntimeEnv({ LOG_LEVEL: "silent" }).logLevel).toBe("silent");
     expect(() => loadProxyRuntimeEnv({ LOG_LEVEL: "verbose" })).toThrow(/LOG_LEVEL/);
+  });
+
+  it("parses the update retry interval and rejects unsafe timer values", () => {
+    expect(
+      loadProxyRuntimeEnv({ DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS: "10000" })
+        .autoUpdateRetryInitialMs,
+    ).toBe(10000);
+    for (const value of ["0", "-1", "1.5", "NaN", "Infinity", "2147483648"]) {
+      expect(() =>
+        loadProxyRuntimeEnv({ DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS: value }),
+      ).toThrow(/DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS/);
+    }
   });
 
   it("flags VITEST as truthy whenever the var is set", () => {

--- a/apps/proxy/src/auto-update.ts
+++ b/apps/proxy/src/auto-update.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import type { Logger } from "pino";
 import { IS_DEV, spawnScript } from "./common/env.js";
+import { loadProxyRuntimeEnv } from "./common/runtime-env.js";
 import { compareStableVersions } from "./common/stable-version.js";
 
 const UPDATE_RETRY_INITIAL_MS = 15 * 60_000;
@@ -29,7 +30,10 @@ export function createRelayAutoUpdater(options: RelayAutoUpdaterOptions): RelayA
   const packagedRuntime = options.packagedRuntime ?? !IS_DEV;
   const available =
     options.enabled && packagedRuntime && options.profileName !== QUICK_TUNNEL_PROFILE;
-  const retryInitialMs = options.retryInitialMs ?? UPDATE_RETRY_INITIAL_MS;
+  const retryInitialMs =
+    options.retryInitialMs ??
+    loadProxyRuntimeEnv().autoUpdateRetryInitialMs ??
+    UPDATE_RETRY_INITIAL_MS;
   const retryMaxMs = options.retryMaxMs ?? UPDATE_RETRY_MAX_MS;
   const spawnRunner =
     options.spawnRunner ??

--- a/apps/proxy/src/common/local-ipc-endpoint.ts
+++ b/apps/proxy/src/common/local-ipc-endpoint.ts
@@ -13,6 +13,7 @@ export function prepareLocalIpcEndpoint(endpoint: string): void {
 
 export function setLocalIpcEndpointPermissions(endpoint: string): void {
   // Do not enable readableAll/writableAll: access must stay limited to this account.
+  // Listeners must not send data until the client writes and passes protocol admission.
   if (isNamedPipeEndpoint(endpoint)) setWindowsPipePermissions(endpoint);
   else chmodSync(endpoint, 0o600);
 }

--- a/apps/proxy/src/common/local-ipc-endpoint.ts
+++ b/apps/proxy/src/common/local-ipc-endpoint.ts
@@ -1,6 +1,7 @@
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { unlinkIfPresent } from "./safe-unlink.js";
+import { setWindowsPipePermissions } from "./windows-pipe-permissions.js";
 
 export function isNamedPipeEndpoint(endpoint: string): boolean {
   return /^\\\\[.?]\\pipe\\/i.test(endpoint);
@@ -11,9 +12,9 @@ export function prepareLocalIpcEndpoint(endpoint: string): void {
 }
 
 export function setLocalIpcEndpointPermissions(endpoint: string): void {
-  // Node uses the Windows pipe DACL; chmod is a filesystem operation, not a pipe ACL setter.
-  // Do not enable readableAll/writableAll. Listeners must not send data before a client writes.
-  if (!isNamedPipeEndpoint(endpoint)) chmodSync(endpoint, 0o600);
+  // Do not enable readableAll/writableAll: access must stay limited to this account.
+  if (isNamedPipeEndpoint(endpoint)) setWindowsPipePermissions(endpoint);
+  else chmodSync(endpoint, 0o600);
 }
 
 export function removeLocalIpcEndpoint(endpoint: string): void {

--- a/apps/proxy/src/common/runtime-env.ts
+++ b/apps/proxy/src/common/runtime-env.ts
@@ -24,6 +24,8 @@ interface ProxyRuntimeEnv {
   relayProxyToken: string | undefined;
   // DEV_ANYWHERE_HOOK_PORT —— 覆盖按 profile 推导的 hook server 端口。
   hookPort: number | undefined;
+  // DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS —— 自动更新失败后的首次重试间隔。
+  autoUpdateRetryInitialMs: number | undefined;
   // CLAUDE_BIN / CODEX_BIN / KIMI_BIN —— 覆盖 config.agentCli 里的 CLI 可执行文件路径。
   claudeBin: string | undefined;
   codexBin: string | undefined;
@@ -57,11 +59,23 @@ function nonEmpty(value: string | undefined): string | undefined {
   return value && value.length > 0 ? value : undefined;
 }
 
+function parseRetryInterval(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const interval = Number(value);
+  if (!Number.isInteger(interval) || interval < 1 || interval > 2_147_483_647) {
+    throw new Error(
+      `Invalid DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS=${JSON.stringify(value)}: expected integer milliseconds 1-2147483647`,
+    );
+  }
+  return interval;
+}
+
 export function loadProxyRuntimeEnv(env: NodeJS.ProcessEnv = process.env): ProxyRuntimeEnv {
   return {
     relayUrl: nonEmpty(env.RELAY_URL),
     relayProxyToken: nonEmpty(env.RELAY_PROXY_TOKEN),
     hookPort: parsePort(env.DEV_ANYWHERE_HOOK_PORT, "DEV_ANYWHERE_HOOK_PORT"),
+    autoUpdateRetryInitialMs: parseRetryInterval(env.DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS),
     claudeBin: nonEmpty(env.CLAUDE_BIN),
     codexBin: nonEmpty(env.CODEX_BIN),
     kimiBin: nonEmpty(env.KIMI_BIN),

--- a/apps/proxy/src/common/windows-pipe-permissions.ts
+++ b/apps/proxy/src/common/windows-pipe-permissions.ts
@@ -102,8 +102,8 @@ Add-Type -TypeDefinition $source -ReferencedAssemblies 'System.dll','System.Core
   return executable;
 }
 
-export function setWindowsPipePermissions(endpoint: string, serverPid = process.pid): void {
-  execFileSync(permissionHelper(), [endpoint, String(serverPid)], {
+export function setWindowsPipePermissions(endpoint: string): void {
+  execFileSync(permissionHelper(), [endpoint, String(process.pid)], {
     timeout: 5_000,
     windowsHide: true,
     stdio: "pipe",

--- a/apps/proxy/src/common/windows-pipe-permissions.ts
+++ b/apps/proxy/src/common/windows-pipe-permissions.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// An administrator's service token makes Administrators the default pipe owner. Its
+// unelevated desktop token cannot use that ACE. Grant the actual user SID explicitly.
+const SOURCE = `using System;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
+
+public static class DevAnywherePipePermissions {
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool GetNamedPipeServerProcessId(SafePipeHandle pipe, out uint pid);
+  [DllImport("advapi32.dll", SetLastError = true)]
+  private static extern bool SetKernelObjectSecurity(SafePipeHandle handle, uint information, byte[] descriptor);
+
+  public static int Main(string[] args) {
+    Console.OutputEncoding = new System.Text.UTF8Encoding(false);
+    try {
+      if (args.Length != 2 || !(args[0].StartsWith(@"\\\\.\\pipe\\") || args[0].StartsWith(@"\\\\?\\pipe\\")))
+        throw new ArgumentException("Expected a local named pipe and its server PID");
+      uint expectedPid = uint.Parse(args[1]);
+      var rights = PipeAccessRights.ReadWrite | PipeAccessRights.ReadPermissions |
+        PipeAccessRights.ChangePermissions | PipeAccessRights.TakeOwnership;
+      using (var pipe = new NamedPipeClientStream(".", args[0].Substring(9), rights,
+          PipeOptions.None, TokenImpersonationLevel.Identification, HandleInheritability.None)) {
+        pipe.Connect(3000);
+        uint serverPid;
+        if (!GetNamedPipeServerProcessId(pipe.SafePipeHandle, out serverPid))
+          throw new Win32Exception(Marshal.GetLastWin32Error());
+        if (serverPid != expectedPid) throw new InvalidOperationException("Named pipe belongs to another process");
+        using (var identity = WindowsIdentity.GetCurrent()) {
+          // Retain local administrative access and explicitly admit this account's desktop token.
+          // Keep other users, low-integrity processes and network logons out.
+          var descriptor = new RawSecurityDescriptor("D:P(D;;GA;;;NU)(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;" +
+            identity.User.Value + ")S:(ML;;NW;;;ME)");
+          var data = new byte[descriptor.BinaryLength];
+          descriptor.GetBinaryForm(data, 0);
+          if (!SetKernelObjectSecurity(pipe.SafePipeHandle, 0x80000014, data))
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+      }
+      return 0;
+    } catch (Exception error) {
+      Console.Error.WriteLine("Cannot secure local pipe: " + error.Message);
+      return 1;
+    }
+  }
+}
+`;
+
+let helperPath: string | undefined;
+
+function permissionHelper(): string {
+  if (helperPath) return helperPath;
+  const directory = join(homedir(), ".dev-anywhere", "helpers");
+  const digest = createHash("sha256").update(SOURCE).digest("hex").slice(0, 20);
+  const executable = join(directory, `pipe-permissions-${digest}.exe`);
+  if (!existsSync(executable)) {
+    mkdirSync(directory, { recursive: true });
+    const candidate = `${executable}.${process.pid}.tmp.exe`;
+    const script = `$ErrorActionPreference = 'Stop';
+$env:PSModulePath = $PSHOME + '\\Modules';
+$source = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${Buffer.from(SOURCE).toString("base64")}'));
+$output = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${Buffer.from(candidate).toString("base64")}'));
+Add-Type -TypeDefinition $source -ReferencedAssemblies 'System.dll','System.Core.dll' -OutputAssembly $output -OutputType ConsoleApplication;`;
+    try {
+      execFileSync(
+        join(
+          process.env.SystemRoot ?? "C:\\Windows",
+          "System32",
+          "WindowsPowerShell",
+          "v1.0",
+          "powershell.exe",
+        ),
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-EncodedCommand",
+          Buffer.from(script, "utf16le").toString("base64"),
+        ],
+        { timeout: 30_000, windowsHide: true, stdio: "pipe" },
+      );
+      try {
+        renameSync(candidate, executable);
+      } catch (error) {
+        // Another process can finish compiling the same source first.
+        if (!existsSync(executable)) throw error;
+      }
+    } finally {
+      rmSync(candidate, { force: true });
+    }
+  }
+  helperPath = executable;
+  return executable;
+}
+
+export function setWindowsPipePermissions(endpoint: string, serverPid = process.pid): void {
+  execFileSync(permissionHelper(), [endpoint, String(serverPid)], {
+    timeout: 5_000,
+    windowsHide: true,
+    stdio: "pipe",
+  });
+}

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -20,7 +20,6 @@ import { createProfileServiceLifecycle } from "./common/profile-service.js";
 import { ServiceLifecycleError } from "./common/service-lifecycle.js";
 import type { ServiceCommandResult } from "./common/service-command-result.js";
 import { requestServiceHost } from "./common/service-host-control.js";
-import { setWindowsPipePermissions } from "./common/windows-pipe-permissions.js";
 
 async function showStatus(): Promise<number> {
   const lines: string[] = [`Profile: ${PROFILE_NAME}`];
@@ -75,11 +74,6 @@ async function runServiceCommand(
 ): Promise<void> {
   let result: ServiceCommandResult;
   try {
-    if (process.platform === "win32" && options.hostCommand && action !== "stop") {
-      // The host survives npm updates. Its freshly loaded command child also repairs the
-      // old host's pipe, so an upgrade does not need an SCM restart to admit desktop clients.
-      setWindowsPipePermissions(SERVICE_HOST_PATH, process.ppid);
-    }
     // The public command chooses a relay. Host commands also serve automatic starts,
     // which must preserve that choice when no new relay was requested.
     if (action !== "stop" && !options.hostCommand) setDesiredDaemonRelay(options.relay);

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -20,6 +20,7 @@ import { createProfileServiceLifecycle } from "./common/profile-service.js";
 import { ServiceLifecycleError } from "./common/service-lifecycle.js";
 import type { ServiceCommandResult } from "./common/service-command-result.js";
 import { requestServiceHost } from "./common/service-host-control.js";
+import { setWindowsPipePermissions } from "./common/windows-pipe-permissions.js";
 
 async function showStatus(): Promise<number> {
   const lines: string[] = [`Profile: ${PROFILE_NAME}`];
@@ -74,6 +75,11 @@ async function runServiceCommand(
 ): Promise<void> {
   let result: ServiceCommandResult;
   try {
+    if (process.platform === "win32" && options.hostCommand && action !== "stop") {
+      // The host survives npm updates. Its freshly loaded command child also repairs the
+      // old host's pipe, so an upgrade does not need an SCM restart to admit desktop clients.
+      setWindowsPipePermissions(SERVICE_HOST_PATH, process.ppid);
+    }
     // The public command chooses a relay. Host commands also serve automatic starts,
     // which must preserve that choice when no new relay was requested.
     if (action !== "stop" && !options.hostCommand) setDesiredDaemonRelay(options.relay);


### PR DESCRIPTION
Windows system services running under an administrator account create named pipes owned by Administrators. The same account's ordinary terminal consequently receives `EPERM` from `dev-anywhere serve status` even though the service is running.

Set explicit access when each local pipe is created: admit the actual user SID, retain local administrator and SYSTEM access, and reject network logons and low-integrity clients. Existing Windows system services load the corrected pipe setup after a one-time service restart following the upgrade; no legacy host migration code is retained.

Automatic-update acceptance now sets `DEV_ANYWHERE_AUTO_UPDATE_RETRY_INITIAL_MS=10000`, keeping the real npm downloads, failure recovery, OS services, retained shells and timer while reducing the retry wait to 10 seconds. Production still defaults to 15 minutes with exponential backoff capped at six hours. The packaged daemon reads the validated runtime setting, and the acceptance run checks the actual retry delay.

Validation: reproduced the pipe failure in an isolated process on the affected Windows machine; the same account's filtered medium-integrity token connected successfully eight times after the permission setup, while its low-integrity token remained denied. Native Windows checks additionally reject a different ordinary account. Local IPC checks, 44 update/configuration checks, Proxy typechecking and lint passed. All six native automatic-update scenarios passed on commit `c876269c`: macOS, Linux and Windows in daemon and system-service modes, including the configured 10-second retry and preserved original shells.
